### PR TITLE
[Feature/#4] 네트워크 모듈 구현

### DIFF
--- a/Projects/Core/Network/Interface/Sources/API/AnyAPIType.swift
+++ b/Projects/Core/Network/Interface/Sources/API/AnyAPIType.swift
@@ -1,0 +1,29 @@
+//
+//  AnyAPIType.swift
+//  CoreNetworkInterface
+//
+//  Created by 임현규 on 7/22/24.
+//
+
+import Moya
+
+public enum AnyAPIType: BaseTargetType {
+  case apiType(BaseTargetType)
+  
+  public init(_ apiType: any BaseTargetType) {
+    self = .apiType(apiType)
+  }
+  
+  public var apiType: any BaseTargetType {
+    switch self {
+    case .apiType(let apiType):
+      return apiType
+    }
+  }
+  
+  public var path: String { apiType.path }
+  
+  public var method: Moya.Method { apiType.method }
+  
+  public var task: Moya.Task { apiType.task }
+}

--- a/Projects/Core/Network/Interface/Sources/API/BaseTargetType.swift
+++ b/Projects/Core/Network/Interface/Sources/API/BaseTargetType.swift
@@ -1,0 +1,25 @@
+//
+//  BaseTargetType.swift
+//  CoreNetwork
+//
+//  Created by 임현규 on 7/21/24.
+//
+
+import Foundation
+import Moya
+
+public protocol BaseTargetType: TargetType {}
+
+public extension BaseTargetType {
+  var baseURL: URL {
+    guard let baseURL = Bundle.main.infoDictionary?["BASE_URL"] as? String else {
+      return URL(string: "")!
+    }
+    
+    return URL(string: baseURL)!
+  }
+  
+  var headers: [String : String]? {
+    return ["Content-type": "application/json"]
+  }
+}

--- a/Projects/Core/Network/Interface/Sources/NetworkInterface.swift
+++ b/Projects/Core/Network/Interface/Sources/NetworkInterface.swift
@@ -1,5 +1,0 @@
-// This is for Tuist
-
-public protocol NetworkInterface {
-
-}

--- a/Projects/Core/Network/Interface/Sources/NetworkManager/NetworkManagable.swift
+++ b/Projects/Core/Network/Interface/Sources/NetworkManager/NetworkManagable.swift
@@ -1,0 +1,23 @@
+//
+//  NetworkManagable.swift
+//  CoreNetworkInterface
+//
+//  Created by 임현규 on 7/22/24.
+//
+
+import Foundation
+
+public protocol NetworkManagable<APIType> {
+  associatedtype APIType: BaseTargetType
+  
+  /// Swift Concurrency로 네트워크 요청하여 얻은 데이터 디코딩 후 반환하는 메소드
+  /// - Parameters:
+  ///   - api: BaseTargetType을 준수하는 API
+  ///   - dto: 디코딩할 타입
+  func reqeust<T: Decodable>(api: APIType, dto: T.Type) async throws -> T
+  
+  /// Swift Concurrency로 네트워크 요청하는 메소드 (요청만 하는 경우)
+  /// - Parameters:
+  ///   - api: BaseTargetType을 준수하는 API
+  func reqeust(api: APIType) async throws
+}

--- a/Projects/Core/Network/Interface/Sources/Provider/Providable.swift
+++ b/Projects/Core/Network/Interface/Sources/Provider/Providable.swift
@@ -1,0 +1,19 @@
+//
+//  Providable.swift
+//  CoreNetworkInterface
+//
+//  Created by 임현규 on 7/22/24.
+//
+
+import Foundation
+import Moya
+
+/// Moya Provider의  네트워크 요청을 async/await로 감싸기 위한 프로토콜
+public protocol Providable<APIType> {
+  associatedtype APIType: BaseTargetType
+  
+  /// swift concurrency로 네트워크 요청, Reponse 반환하는 메소드
+  ///  - Parameters:
+  ///   - api: BaseTargetType을 준수하는 API
+  func reqeust(api: APIType) async throws -> Response
+}

--- a/Projects/Core/Network/Project.swift
+++ b/Projects/Core/Network/Project.swift
@@ -7,7 +7,11 @@ let project = Project.makeModule(
     targets: [    
         .core(
             interface: .Network,
-            factory: .init()
+            factory: .init(
+                dependencies: [
+                    .shared(implements: .ThirdPartyLib)
+                ]
+            )
         ),
         .core(
             implements: .Network,

--- a/Projects/Core/Network/Sources/NetworkManager/NetworkManager.swift
+++ b/Projects/Core/Network/Sources/NetworkManager/NetworkManager.swift
@@ -1,0 +1,61 @@
+//
+//  NetworkManager.swift
+//  CoreNetworkInterface
+//
+//  Created by 임현규 on 7/22/24.
+//
+
+import Foundation
+import CoreNetworkInterface
+import ComposableArchitecture
+
+// MARK: - NetworkManagagner
+
+public struct NetworkManager {
+  public typealias APIType = AnyAPIType
+
+  private let provider: any Providable<APIType>
+  
+  public let jsonDecoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return decoder
+  }()
+  
+  public init(_ provider: any Providable<APIType>) {
+    self.provider = provider
+  }
+  
+  public init() {
+    self.provider = Provider<APIType>()
+  }
+}
+
+// MARK: - NetworkManagable
+
+extension NetworkManager: NetworkManagable {
+  public func reqeust<T>(api: APIType, dto: T.Type) async throws -> T where T : Decodable {
+    let response = try await provider.reqeust(api: api)
+    let data = try jsonDecoder.decode(dto, from: response.data)
+    return data
+  }
+  
+  public func reqeust(api: APIType) async throws {
+    _ = try await provider.reqeust(api: api)
+  }
+}
+
+// MARK: - DependencyValues
+
+extension DependencyValues {
+  public var network: NetworkManager {
+    get { self[NetworkManager.self] }
+    set { self[NetworkManager.self] = newValue }
+  }
+}
+
+// MARK: - DependencyKey
+
+extension NetworkManager: DependencyKey {
+  public static var liveValue: NetworkManager = NetworkManager()
+}

--- a/Projects/Core/Network/Sources/Provider/Provider.swift
+++ b/Projects/Core/Network/Sources/Provider/Provider.swift
@@ -1,0 +1,32 @@
+//
+//  Provider.swift
+//  CoreNetworkInterface
+//
+//  Created by 임현규 on 7/22/24.
+//
+
+import Foundation
+import CoreNetworkInterface
+import Moya
+
+struct Provider<APIType: BaseTargetType>: Providable {
+  private let moyaProvider = MoyaProvider<APIType>()
+  
+  func reqeust(api: APIType) async throws -> Response {
+    return try await withCheckedThrowingContinuation { continuation in
+      moyaProvider.request(api) { result in
+        switch result {
+        case let .success(response) where 200..<300 ~= response.statusCode:
+          continuation.resume(returning: response)
+        case let .success(response) where 300... ~= response.statusCode:
+          continuation.resume(throwing: MoyaError.statusCode(response))
+        case let .failure(error):
+          continuation.resume(throwing: error)
+        default:
+          let error = NSError(domain: "Unkowned Error", code: 0)
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+}

--- a/Projects/Core/Network/Sources/Source.swift
+++ b/Projects/Core/Network/Sources/Source.swift
@@ -1,1 +1,0 @@
-// This is for Tuist


### PR DESCRIPTION
이슈 #4 

## 완료된 기능
- Moya Provider 네트워크 요청 async/await로 래핑
- Domain 모듈에서 API 정의할 수 있도록 BaseTargetType 구현
- NetworkManager 구현 (네트워크 요청 및 디코딩)

## 전달 사항
TCA의 Dependency를 통해서 의존성을 관리하다보니 실질적으로 DIP를 통해 의존성 주입이 이뤄지지 않아서 NetworkManager 구현부에 살짝 어색한 부분이 있는데 이 부분에 대해서 얘기해보면 좋을 거 같슴다 


Domain 쪽에서 사용할 때 아래처럼 사용해주시면 됩니다

``` swift
// HomeFeature Interface

enum HomeAPI {
  case fetchBottles
}

enum HomeAPI: BaseTargetType {
  var path: String {
    switch self {
    case .fetchBottles:
      return "/v1/bottles"
    }
  }
  
  var method: Moya.Method {
    switch self {
    case .fetchBottles:
      return .get
    }
  }
  
  var task: Moya.Task {
    switch self {
    case .fetchBottles:
      return .requestPlain
    }
  }
}
```

``` swift
// HomeFeature Impelements

public struct HomeClient {
  @Dependency(\.network) var network
  
  public func someMethod() async throws {
    try await network.reqeust(api: .apiType(HomeEndpoint.fetchBottles))
  }
}

``` 

