### PR TITLE
[Feature/#28] 버튼 생성 모디파이어들 추가

### DIFF
--- a/Projects/Core/Util/Sources/Modifiers/AsButtonModifier.swift
+++ b/Projects/Core/Util/Sources/Modifiers/AsButtonModifier.swift
@@ -1,0 +1,28 @@
+//
+//  AsButtonModifier.swift
+//  CoreUtil
+//
+//  Created by JongHoon on 7/27/24.
+//
+
+import SwiftUI
+
+private struct AsButtonModifier: ViewModifier {
+  private let action: () -> Void
+  
+  init(action: @escaping () -> Void) {
+    self.action = action
+  }
+  
+  func body(content: Content) -> some View {
+    Button(action: action) {
+      content
+    }
+  }
+}
+
+public extension View {
+  func asButton(action: @escaping () -> Void) -> some View {
+    modifier(AsButtonModifier(action: action))
+  }
+}

--- a/Projects/Core/Util/Sources/Modifiers/AsDebounceButtonModifier.swift
+++ b/Projects/Core/Util/Sources/Modifiers/AsDebounceButtonModifier.swift
@@ -1,0 +1,29 @@
+//
+//  AsDebounceButtonModifier.swift
+//  CoreUtil
+//
+//  Created by JongHoon on 7/27/24.
+//
+
+import SwiftUI
+
+private struct AsDebounceButtonModifier: ViewModifier {
+  private let action: () -> Void
+  
+  init(action: @escaping () -> Void) {
+    self.action = action
+  }
+  
+  func body(content: Content) -> some View {
+    content
+      .asButton {
+        action()
+      }
+  }
+}
+
+public extension View {
+  func asDebounceButton(action: @escaping () -> Void) -> some View {
+    modifier(AsDebounceButtonModifier(action: action))
+  }
+}

--- a/Projects/Core/Util/Sources/Modifiers/AsThrottleButtonModifier.swift
+++ b/Projects/Core/Util/Sources/Modifiers/AsThrottleButtonModifier.swift
@@ -1,0 +1,29 @@
+//
+//  AsThrottleButtonModifier.swift
+//  CoreUtil
+//
+//  Created by JongHoon on 7/27/24.
+//
+
+import SwiftUI
+
+private struct AsThrottleButtonModifier: ViewModifier {
+  private let action: () -> Void
+  
+  init(action: @escaping () -> Void) {
+    self.action = action
+  }
+  
+  func body(content: Content) -> some View {
+    content
+      .asButton {
+        action()
+      }
+  }
+}
+
+public extension View {
+  func asThrottleButton(action: @escaping () -> Void) -> some View {
+    modifier(AsThrottleButtonModifier(action: action))
+  }
+}


### PR DESCRIPTION
## 작업 사항
- 일반 버튼, 스로틀 버튼, 디바운스 버튼 생성 모디 파이어 추가

## 참고 사항
- 아직 내부 로직은 구현안헀는데 상황에 맞게 일단 적용해놓고 내부 로직은 출히하고 구현하자
- TCA에도 debounce가 있지만 내가 알기로는 비동기 로직 실행하는 메소드 사용할 때만 적용이 가능해서 모디 파이어들 따로 구현해서 run 메소드 사용하지 않는 상황에도 활용해보고 싶어서 추가했어!
  - [TCA debounce 문서](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/effect/debounce(id:for:scheduler:options:))