### PR TITLE
[Feature/#55] ClipList DesignSystem 구현

### DIFF
--- a/Projects/Shared/DesignSystem/Example/Sources/DesignSystemExampleView/DesignSystemExampleView.swift
+++ b/Projects/Shared/DesignSystem/Example/Sources/DesignSystemExampleView/DesignSystemExampleView.swift
@@ -105,7 +105,28 @@ struct DesignSystemExampleView: View {
               .font(.headline)
           }
         )
-     
+        
+        
+        Section(
+          content: {
+            NavigationLink(
+              destination:
+                ClipListContainerViewTest(),
+              label: { Text("ClipListContainerView") }
+            )
+            
+            NavigationLink(
+              destination:
+                ClipListViewTest(),
+              label: { Text("ClipListView") }
+            )
+          },
+          header: {
+            Text("Card")
+              .font(.headline)
+          }
+        )
+        
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("Design System Example View")
       }

--- a/Projects/Shared/DesignSystem/Example/Sources/SubViews/ClipListTest/ClipListContainerViewTest.swift
+++ b/Projects/Shared/DesignSystem/Example/Sources/SubViews/ClipListTest/ClipListContainerViewTest.swift
@@ -1,0 +1,35 @@
+//
+//  ClipListContainerViewTest.swift
+//  SharedDesignSystem
+//
+//  Created by 임현규 on 8/2/24.
+//
+
+import SwiftUI
+
+public struct ClipListContainerViewTest: View {
+  public init() {}
+  public var body: some View {
+    ClipListContainerView(
+      clipItemList: [
+        ClipItem(
+          title: "내 키워드를 참고해보세요",
+          list: ["직장인", "MBTI", "city_name", "height", "흡연 안해요", "술을 즐겨요"]
+        ),
+        ClipItem(
+          title: "나의 성격은",
+          list: ["적극적인", "열정적인", "예의바른", "자유로운", "쿨한"]
+        ),
+        ClipItem(
+          title: "내가 푹 빠진 취미는",
+          list: ["코인노래방", "헬스", "드라이브", "만화 웹툰 정주행", "자전거"]
+        )
+      ]
+    )
+    .padding(.horizontal, .xl)
+  }
+}
+
+#Preview {
+  ClipListContainerViewTest()
+}

--- a/Projects/Shared/DesignSystem/Example/Sources/SubViews/ClipListTest/ClipListViewTest.swift
+++ b/Projects/Shared/DesignSystem/Example/Sources/SubViews/ClipListTest/ClipListViewTest.swift
@@ -1,0 +1,21 @@
+//
+//  ClipListViewTest.swift
+//  SharedDesignSystem
+//
+//  Created by 임현규 on 8/2/24.
+//
+
+import SwiftUI
+
+public struct ClipListViewTest: View {
+  public init() {}
+  public var body: some View {
+    ClipListView(
+      clipItem: ClipItem(
+        title: "내가 푹 빠진 취미는",
+        list: ["코인노래방", "헬스", "드라이브", "만화 웹툰 정주행", "자전거"]
+      )
+    )
+    .padding(.sm)
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/Card/ChipListLayout.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/ChipListLayout.swift
@@ -1,0 +1,97 @@
+//
+//  ChipListLayout.swift
+//  SharedDesignSystem
+//
+//  Created by 임현규 on 8/2/24.
+//
+
+import SwiftUI
+
+import CoreLoggerInterface
+
+struct ClipListLayout: Layout {
+  var spacing: Spacer.BottleSpacingType = .xs
+  var rowSpacing: Spacer.BottleSpacingType = .sm
+  
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    let maxWidth = proposal.width ?? 0
+    var height: CGFloat = 0
+    let rows = generateRows(maxWidth, proposal, subviews)
+    
+    // rows들로 height 계산
+    for (index, row) in rows.enumerated() {
+      if index == (rows.count - 1) {
+        height += row.maxHeight(proposal)
+      } else {
+        height += row.maxHeight(proposal) + rowSpacing.minLength
+      }
+    }
+    
+    return .init(width: maxWidth, height: height)
+  }
+  
+  func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+    var origin = bounds.origin
+    let maxWidth = bounds.width
+    let rows = generateRows(maxWidth, proposal, subviews)
+    
+    // 첫 번째 열부터 view 배치
+    for row in rows {
+      origin.x = bounds.minX
+      
+      for view in row {
+        let viewSize = view.sizeThatFits(proposal)
+        view.place(at: origin, proposal: proposal)
+        origin.x += (viewSize.width + spacing.minLength)
+      }
+      
+      origin.y += row.maxHeight(proposal) + rowSpacing.minLength
+    }
+  }
+  
+  func generateRows(_ maxWidth: CGFloat, _ proposal: ProposedViewSize, _ subviews: Subviews) -> [[LayoutSubviews.Element]] {
+    var row = [LayoutSubviews.Element]()
+    var rows = [[LayoutSubviews.Element]]()
+    
+    var origin = CGRect.zero.origin
+    
+    for view in subviews {
+      let viewSize = view.sizeThatFits(proposal)
+      
+      // view를 배치했을 떄 최대 너비보다 큰 경우
+      if (origin.x + viewSize.width + spacing.minLength) > maxWidth {
+        // 현재까지 row에 담겨있는 view를 rows에 추가한 뒤 row 초기화
+        rows.append(row)
+        row.removeAll()
+        
+        origin.x = 0
+        // row에 view 추가 -> 새로운 row
+        row.append(view)
+        
+        origin.x += (viewSize.width + spacing.minLength)
+      } else {
+        // view 배치했을 때 최대 너비보다 작은 경우
+        // row에 view 추가
+        row.append(view)
+        origin.x += (viewSize.width + spacing.minLength)
+      }
+    }
+    
+    // 마지막 row 처리
+    if !row.isEmpty {
+      rows.append(row)
+      row.removeAll()
+    }
+    
+    return rows
+  }
+}
+
+// MARK: - Private Extension
+private extension [LayoutSubviews.Element] {
+  func maxHeight(_ proposal: ProposedViewSize) -> CGFloat {
+    return self.compactMap { view in
+      return view.sizeThatFits(proposal).height
+    }.max() ?? 0
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/Card/ClipItem.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/ClipItem.swift
@@ -1,0 +1,18 @@
+//
+//  ClipItem.swift
+//  SharedDesignSystem
+//
+//  Created by 임현규 on 8/2/24.
+//
+
+import Foundation
+
+public struct ClipItem: Hashable {
+  var title: String
+  var list: [String]
+  
+  public init(title: String, list: [String]) {
+    self.title = title
+    self.list = list
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListContainerView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListContainerView.swift
@@ -16,8 +16,8 @@ public struct ClipListContainerView: View {
   
   public var body: some View {
     VStack(spacing: .xl) {
-      ForEach(clipItemList, id: \.self) { clip in
-        ClipListView(title: clip.title, tagList: clip.list)
+      ForEach(clipItemList, id: \.self) { clipItem in
+        ClipListView(clipItem: clipItem)
       }
     }
     .padding(.horizontal, .md)

--- a/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListContainerView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListContainerView.swift
@@ -1,0 +1,33 @@
+//
+//  ClipListContainerView.swift
+//  SharedDesignSystem
+//
+//  Created by 임현규 on 8/2/24.
+//
+
+import SwiftUI
+
+public struct ClipListContainerView: View {
+  private let clipItemList: [ClipItem]
+  
+  public init(clipItemList: [ClipItem]) {
+    self.clipItemList = clipItemList
+  }
+  
+  public var body: some View {
+    VStack(spacing: .xl) {
+      ForEach(clipItemList, id: \.self) { clip in
+        ClipListView(title: clip.title, tagList: clip.list)
+      }
+    }
+    .padding(.horizontal, .md)
+    .padding(.vertical, .xl)
+    .overlay(
+      RoundedRectangle(cornerRadius: BottleRadiusType.xl.value)
+        .strokeBorder(
+          ColorToken.border(.primary).color,
+          lineWidth: 1
+        )
+    )
+  }
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListView.swift
@@ -8,12 +8,10 @@
 import SwiftUI
 
 public struct ClipListView: View {
-  private let title: String
-  private let tagList: [String]
+  private let clipItem: ClipItem
   
-  public init(title: String, tagList: [String]) {
-    self.title = title
-    self.tagList = tagList
+  public init(clipItem: ClipItem) {
+    self.clipItem = clipItem
   }
   
   public var body: some View {
@@ -30,7 +28,7 @@ public struct ClipListView: View {
 private extension ClipListView {
   var titleText: some View {
     WantedSansStyleText(
-      title,
+      clipItem.title,
       style: .subTitle2,
       color: .tertiary
     )
@@ -38,7 +36,7 @@ private extension ClipListView {
   
   var clipList: some View {
     ClipListLayout() {
-      ForEach(tagList, id: \.self) { item in
+      ForEach(clipItem.list, id: \.self) { item in
         WantedSansStyleText(
           item,
           style: .body,

--- a/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/ClipListView.swift
@@ -1,0 +1,60 @@
+//
+//  ClipListView.swift
+//  DesignSystemExample
+//
+//  Created by 임현규 on 8/2/24.
+//
+
+import SwiftUI
+
+public struct ClipListView: View {
+  private let title: String
+  private let tagList: [String]
+  
+  public init(title: String, tagList: [String]) {
+    self.title = title
+    self.tagList = tagList
+  }
+  
+  public var body: some View {
+    VStack(spacing: .sm) {
+      HStack(spacing: 0) {
+        titleText
+        Spacer()
+      }
+      clipList
+    }
+  }
+}
+
+private extension ClipListView {
+  var titleText: some View {
+    WantedSansStyleText(
+      title,
+      style: .subTitle2,
+      color: .tertiary
+    )
+  }
+  
+  var clipList: some View {
+    ClipListLayout() {
+      ForEach(tagList, id: \.self) { item in
+        WantedSansStyleText(
+          item,
+          style: .body,
+          color: .secondary
+        )
+        .frame(height: 36)
+        .padding(.horizontal, .sm)
+        .overlay(
+          RoundedRectangle(cornerRadius: BottleRadiusType.xs.value)
+            .strokeBorder(
+              ColorToken.border(.primary).color,
+              lineWidth: 1
+            )
+        )
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
이슈 #55 

https://github.com/user-attachments/assets/80fdec93-3bf1-4d19-8dd0-64a3b3610c45



## 완료한 기능
- ClipListView 구현
- ClipListContainerView 구현
- ClipItem 구현
- ClipListLayout 구현

## 전달 사항
- Layout 프로토콜 채택한 ClipListLayout 구현해서 부모 뷰의 최대 너비와 배치했을 때 x 좌표 위치 고려하면서 아래로 position 조정하면서 구현하는 방식으로 했어!

- 지금은 ClipList 쓰는 GUI들 3개 Section으로 고정되어있는데 확장성 고려해서 ClipItem 배열받아서 그리도록 함!

- 나중에 보틀 보관함 구현할 때 ClipListContainerView 사용하면 될 듯!