### PR TITLE
[feature/#102] 보틀 보관함 상세 탭뷰 구현

### DIFF
--- a/Projects/Feature/BottleStorage/Example/Sources/AppView.swift
+++ b/Projects/Feature/BottleStorage/Example/Sources/AppView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 import FeatureBottleStorageInterface
+import DomainAuth
+import DomainAuthInterface
 
 import ComposableArchitecture
 
@@ -19,6 +21,12 @@ struct AppView: App {
         initialState: BottleStorageFeature.State(),
         reducer: { BottleStorageFeature()._printChanges() }
       ))
+      .onAppear {
+        AuthClient.liveValue.saveToken(token: .init(
+          accessToken: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzIzMTE3ODk1LCJleHAiOjE3MjMxNTM4OTV9.HjjnS1onaAUA6nJGOV-f6FE55eAihUGTFNYGmmyETQc",
+          refershToken: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzIzMTE3ODk1LCJleHAiOjE3Mzc2MzMwOTV9.Af-L2h_5pBQWrZCc1OQI3tm1DGwowqCAId-rK5vAPaQ"
+        ))
+      }
     }
   }
 }

--- a/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageFeature.swift
@@ -30,11 +30,15 @@ extension BottleStorageFeature {
         state.doneBottlsList = bottleStorageList.doneBottles
         return .none
         
+      case .bottleStorageItemDidTapped:
+        state.path.append(.pingPongDetail(.init()))
+        return .none
+        
       case let .bottleActiveStateTabButtonTapped(activeState):
         state.selectedActiveStateTab = activeState
         return .none
         
-      case .binding:
+      case .binding, .path:
         return .none
       }
     }
@@ -42,3 +46,11 @@ extension BottleStorageFeature {
   }
 }
 
+extension BottleStorageFeature {
+  // MARK: - Path
+  
+  @Reducer(state: .equatable)
+  public enum Path {
+    case pingPongDetail(PingPongDetailFeature)
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageFeatureInterface.swift
@@ -37,6 +37,8 @@ public struct BottleStorageFeature {
     var activeBottleList: [BottleStorageItem]?
     var doneBottlsList: [BottleStorageItem]?
     
+    var path = StackState<Path.State>()
+    
     public init() {
       self.bottleActiveStateTabs = BottleActiveState.allCases
       self.selectedActiveStateTab = .active
@@ -52,13 +54,17 @@ public struct BottleStorageFeature {
     
     // 보틀 리스트
     case bottleStorageListFetched(BottleStorageList)
+    case bottleStorageItemDidTapped
     
     // ETC.
+    case path(StackAction<Path.State, Path.Action>)
     case binding(BindingAction<State>)
   }
   
   public var body: some ReducerOf<Self> {
+    BindingReducer()
     reducer
+      .forEach(\.path, action: \.path)
   }
 }
 

--- a/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageView.swift
@@ -20,7 +20,7 @@ public struct BottleStorageView: View {
   
   public var body: some View {
     WithPerceptionTracking {
-      NavigationStack {
+      NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
         VStack(spacing: 0.0) {
           bottleActiveStateSelectTab
           
@@ -30,6 +30,15 @@ public struct BottleStorageView: View {
             .padding(.bottom, 36.0)
         }
         .frame(maxHeight: .infinity, alignment: .top)
+      } destination: { store in
+        WithPerceptionTracking {
+          switch store.state {
+          case .pingPongDetail:
+            if let store = store.scope(state: \.pingPongDetail, action: \.pingPongDetail) {
+              PingPongDetailView(store: store)
+            }
+          }
+        }
       }
       .onAppear {
         store.send(.onAppear)
@@ -99,6 +108,9 @@ private extension BottleStorageView {
               imageURL: bottle.userImageUrl,
               isRead: bottle.isRead ?? false
             )
+            .asButton {
+              store.send(.bottleStorageItemDidTapped)
+            }
           }
         }
       }

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailFeature.swift
@@ -1,0 +1,55 @@
+//
+//  PingPongDetailFeature.swift
+//  FeatureBottleStorageInterface
+//
+//  Created by JongHoon on 8/10/24.
+//
+
+import Foundation
+
+import CoreLoggerInterface
+import DomainBottle
+
+import ComposableArchitecture
+
+extension PingPongDetailFeature {
+  public init() {
+    @Dependency(\.bottleClient) var bottleClient
+    
+    let reducer = Reduce<State, Action> { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+        
+      case let .pingPongDetailViewTabDidTapped(tab):
+        state.selectedTab = tab
+        return .none
+        
+      case .binding, .introduction, .questionAndAnswer, .matching:
+        return .none
+      }
+    }
+    
+    self.init(reducer: reducer)
+  }
+}
+
+public enum PingPongDetailViewTabType: CaseIterable {
+  case introduction
+  case questionAndAnswer
+  case matching
+  
+  var title: String {
+    switch self {
+    case .introduction:
+      return "소개"
+      
+    case .questionAndAnswer:
+      return "가치관 문답"
+
+    case .matching:
+      return "매칭"
+    }
+  }
+}
+

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailFeatureInterface.swift
@@ -1,0 +1,64 @@
+//
+//  PingPongDetailFeatureInterface.swift
+//  FeatureBottleStorageInterface
+//
+//  Created by JongHoon on 8/10/24.
+//
+
+import Foundation
+
+import DomainBottleInterface
+
+import ComposableArchitecture
+
+@Reducer
+public struct PingPongDetailFeature {
+  private let reducer: Reduce<State, Action>
+  
+  public init(reducer: Reduce<State, Action>) {
+    self.reducer = reducer
+  }
+  
+  @ObservableState
+  public struct State: Equatable {
+    var introduction: IntroductionFeature.State
+    var questionAndAnswer: QuestionAndAnswerFeature.State
+    var matching: MatchingFeature.State
+    var selectedTab: PingPongDetailViewTabType
+    
+    public init() {
+      self.introduction = .init()
+      self.questionAndAnswer = .init()
+      self.matching = .init()
+      self.selectedTab = .introduction
+    }
+  }
+  
+  public enum Action: BindableAction {
+    // View Life Cycle
+    case onAppear
+    
+    case pingPongDetailViewTabDidTapped(_: PingPongDetailViewTabType)
+    
+    // ETC.
+    case introduction(IntroductionFeature.Action)
+    case questionAndAnswer(QuestionAndAnswerFeature.Action)
+    case matching(MatchingFeature.Action)
+    case binding(BindingAction<State>)
+  }
+  
+  public var body: some ReducerOf<Self> {
+    BindingReducer()
+    Scope(state: \.introduction, action: \.introduction) {
+      IntroductionFeature()
+    }
+    Scope(state: \.questionAndAnswer, action: \.questionAndAnswer) {
+      QuestionAndAnswerFeature()
+    }
+    Scope(state: \.matching, action: \.matching) {
+      MatchingFeature()
+    }
+    reducer
+  }
+}
+

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailView.swift
@@ -1,0 +1,58 @@
+//
+//  PingPongDetail.swift
+//  FeatureBottleStorageInterface
+//
+//  Created by JongHoon on 8/10/24.
+//
+
+import SwiftUI
+
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+public struct PingPongDetailView: View {
+  @Perception.Bindable private var store: StoreOf<PingPongDetailFeature>
+  
+  public init(store: StoreOf<PingPongDetailFeature>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    WithPerceptionTracking {
+      VStack(alignment: .leading, spacing: 0.0) {
+        tabButtons
+          switch store.selectedTab {
+          case .introduction:
+            IntroductionView(store: store.scope(state: \.introduction, action: \.introduction))
+            
+          case .questionAndAnswer:
+            QuestionAndAnswerView(store: store.scope(state: \.questionAndAnswer, action: \.questionAndAnswer))
+            
+          case .matching:
+            MatchingView(store: store.scope(state: \.matching, action: \.matching))
+        }
+      }
+    }
+  }
+}
+
+private extension PingPongDetailView {
+  var tabButtons: some View {
+    HStack(spacing: .xs) {
+      ForEach(PingPongDetailViewTabType.allCases, id: \.title, content: { tab in
+        OutlinedStyleButton(
+          .small(contentType: .text),
+          title: tab.title,
+          buttonType: .throttle,
+          isSelected: store.selectedTab == tab,
+          action: { store.send(.pingPongDetailViewTabDidTapped(tab)) }
+        )
+      })
+      
+      Spacer()
+    }
+    .padding(.sm)
+    .frame(maxWidth: .infinity)
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeature.swift
@@ -1,0 +1,27 @@
+//
+//  IntroductionFeature.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import Foundation
+
+import CoreLoggerInterface
+
+import ComposableArchitecture
+
+extension IntroductionFeature {
+  public init() {
+    let reducer = Reduce<State, Action> { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+        
+      case .binding:
+        return .none
+      }
+    }
+    self.init(reducer: reducer)
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeatureInterface.swift
@@ -1,0 +1,41 @@
+//
+//  IntroductionFeatureInterface.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import Foundation
+
+import DomainBottleInterface
+
+import ComposableArchitecture
+
+@Reducer
+public struct IntroductionFeature {
+  private let reducer: Reduce<State, Action>
+  
+  public init(reducer: Reduce<State, Action>) {
+    self.reducer = reducer
+  }
+  
+  @ObservableState
+  public struct State: Equatable {
+    public init () {
+      
+    }
+  }
+  
+  public enum Action: BindableAction {
+    // View Life Cycle
+    case onAppear
+    
+    // ETC.
+    case binding(BindingAction<State>)
+  }
+  
+  public var body: some ReducerOf<Self> {
+    reducer
+  }
+}
+

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionView.swift
@@ -1,0 +1,54 @@
+//
+//  IntroductionView.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import SwiftUI
+
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+public struct IntroductionView: View {
+  @Perception.Bindable private var store: StoreOf<IntroductionFeature>
+  
+  public init(store: StoreOf<IntroductionFeature>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    WithPerceptionTracking {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 0.0) {
+            
+          
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+          Text("Introduction")
+            .frame(height: 200.0)
+        }
+        .frame(maxWidth: .infinity)
+      }
+    }
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingFeature.swift
@@ -1,0 +1,27 @@
+//
+//  MatchingFeature.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import Foundation
+
+import CoreLoggerInterface
+
+import ComposableArchitecture
+
+extension MatchingFeature {
+  public init() {
+    let reducer = Reduce<State, Action> { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+        
+      case .binding:
+        return .none
+      }
+    }
+    self.init(reducer: reducer)
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingFeatureInterface.swift
@@ -1,0 +1,41 @@
+//
+//  MatchingFeatureInterface.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import Foundation
+
+import DomainBottleInterface
+
+import ComposableArchitecture
+
+@Reducer
+public struct MatchingFeature {
+  private let reducer: Reduce<State, Action>
+  
+  public init(reducer: Reduce<State, Action>) {
+    self.reducer = reducer
+  }
+  
+  @ObservableState
+  public struct State: Equatable {
+    public init() {
+      
+    }
+  }
+  
+  public enum Action: BindableAction {
+    // View Life Cycle
+    case onAppear
+    
+    // ETC.
+    case binding(BindingAction<State>)
+  }
+  
+  public var body: some ReducerOf<Self> {
+    reducer
+  }
+}
+

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
@@ -1,0 +1,31 @@
+//
+//  MatchingView.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import SwiftUI
+
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+public struct MatchingView: View {
+  @Perception.Bindable private var store: StoreOf<MatchingFeature>
+  
+  public init(store: StoreOf<MatchingFeature>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    WithPerceptionTracking {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 0.0) {
+          Text("Matching")
+        }
+        .frame(maxHeight: .infinity)
+      }
+    }
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeature.swift
@@ -1,0 +1,27 @@
+//
+//  QuestionAndAnswerFeature.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import Foundation
+
+import CoreLoggerInterface
+
+import ComposableArchitecture
+
+extension QuestionAndAnswerFeature {
+  public init() {
+    let reducer = Reduce<State, Action> { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+        
+      case .binding:
+        return .none
+      }
+    }
+    self.init(reducer: reducer)
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeatureInterface.swift
@@ -1,0 +1,40 @@
+//
+//  QuestionAndAnswerFeatureInterface.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import Foundation
+
+import DomainBottleInterface
+
+import ComposableArchitecture
+
+@Reducer
+public struct QuestionAndAnswerFeature {
+  private let reducer: Reduce<State, Action>
+  
+  public init(reducer: Reduce<State, Action>) {
+    self.reducer = reducer
+  }
+  
+  @ObservableState
+  public struct State: Equatable {
+    public init() {
+      
+    }
+  }
+  
+  public enum Action: BindableAction {
+    // View Life Cycle
+    case onAppear
+    
+    // ETC.
+    case binding(BindingAction<State>)
+  }
+  
+  public var body: some ReducerOf<Self> {
+    reducer
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerView.swift
@@ -1,0 +1,31 @@
+//
+//  QuestionAndAnswerView.swift
+//  FeatureBottleStorage
+//
+//  Created by JongHoon on 8/11/24.
+//
+
+import SwiftUI
+
+import SharedDesignSystem
+
+import ComposableArchitecture
+
+public struct QuestionAndAnswerView: View {
+  @Perception.Bindable private var store: StoreOf<QuestionAndAnswerFeature>
+  
+  public init(store: StoreOf<QuestionAndAnswerFeature>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    WithPerceptionTracking {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 0.0) {
+          Text("가치관 문답")
+        }
+        .frame(maxWidth: .infinity)
+      }
+    }
+  }
+}

--- a/Projects/Feature/SandBeach/Example/Sources/AppView.swift
+++ b/Projects/Feature/SandBeach/Example/Sources/AppView.swift
@@ -9,7 +9,7 @@ import ComposableArchitecture
 struct AppView: App {
   private let rootStore = Store(
     initialState: SandBeachRootFeature.State(
-      sandBeach: .init(userState: .noIntroduction)),
+      sandBeach: .init(userState: .)),
     reducer: { SandBeachRootFeature() })
   
   var body: some Scene {

--- a/Projects/Shared/DesignSystem/Sources/Extension/PreferenceKey/CGSizePreferenceKey.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/PreferenceKey/CGSizePreferenceKey.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  DesignSystemExample
+//
+//  Created by JongHoon on 8/10/24.
+//
+
+import SwiftUI
+
+public struct CGSizePreferenceKey: PreferenceKey {
+  public static var defaultValue: CGSize = .zero
+  public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
+}

--- a/Projects/Shared/DesignSystem/Sources/Extension/View+Extensions.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/View+Extensions.swift
@@ -49,3 +49,17 @@ extension View {
     }
   }
 }
+
+// MARK: - View Layout
+
+extension View {
+  public func readSize(onChange: @escaping (CGSize) -> Void) -> some View {
+    background(
+      GeometryReader { geometry in
+        Color.clear
+          .preference(key: CGSizePreferenceKey.self, value: geometry.size)
+      }
+    )
+    .onPreferenceChange(CGSizePreferenceKey.self, perform: onChange)
+  }
+}


### PR DESCRIPTION
## 작업 사항
- 보틀 보관함 상세 탭뷰 구현

## 고민 사항
- TabView로 깜싸면 내부 View의 크기에 맞게 늘어나지 않아 동적으로 높이 조절하기어려움, view+ extension에 view의 size를알 수 있는 메소드 만들었는데 이걸 사용해도 잘안됨 [참고 브랜치](https://github.com/Nexters/Bottles_iOS/tree/%ED%83%AD%EB%B7%B0-%EB%AC%B8%EC%A0%9C)
