### PR TITLE
[Feature/#148] UITabBarController TabBar hidden 처리

### DIFF
--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailView.swift
@@ -54,7 +54,7 @@ public struct PingPongDetailView: View {
         }
       }
     )
-    .toolbar(.hidden, for: .bottomBar)
+    .ignoresSafeArea(.all, edges: .bottom)
   }
 }
 

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionView.swift
@@ -74,7 +74,7 @@ public struct IntroductionView: View {
           .disabled(store.isStopped == true)
           
           Spacer()
-            .frame(height: 8.0)
+            .frame(height: 30)
         }
         .padding(.horizontal, 16.0)
         .padding(.top, 32.0)

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
@@ -40,6 +40,9 @@ public struct MatchingView: View {
           
           Spacer()
           bottomButton
+          
+          Spacer()
+            .frame(height: 30)
         }
         .padding(.horizontal, .md)
         .frame(maxHeight: .infinity)

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerView.swift
@@ -109,6 +109,9 @@ public struct QuestionAndAnswerView: View {
             .disabled(store.isStopped == true)
             Spacer()
           }
+          
+          Spacer()
+            .frame(height: 14)
         }
         .padding(.md)
         .frame(maxWidth: .infinity)
@@ -127,6 +130,8 @@ public struct QuestionAndAnswerView: View {
       }
       .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .background(to: ColorToken.background(.primary))
+      .toolbar(.hidden, for: .bottomBar)
+
     }
   }
 }

--- a/Projects/Feature/ProfileSetup/Interface/Sources/IntroductionSetup/IntroductionSetupView.swift
+++ b/Projects/Feature/ProfileSetup/Interface/Sources/IntroductionSetup/IntroductionSetupView.swift
@@ -39,6 +39,10 @@ public struct IntroductionSetupView: View {
         }
       }
     }
+    .onLoad {
+      store.send(.onLoad)
+    }
+    .ignoresSafeArea(.all, edges: .bottom)
     .toolbar(.hidden, for: .bottomBar)
   }
 }

--- a/Projects/Feature/Sources/TabView/MainTabView.swift
+++ b/Projects/Feature/Sources/TabView/MainTabView.swift
@@ -44,18 +44,9 @@ public struct MainTabView: View {
   }
 }
 
-extension UITabBarController { 
+extension UITabBarController {
   open override func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
-    var tabFrame = self.tabBar.frame
-    tabFrame.size.height = 0.0
-    tabFrame.origin.y = self.view.frame.size.height - 0.0
-    tabBar.frame = tabFrame
-    
-    if let shadowView = view.subviews.first(where: { $0.accessibilityIdentifier == "TabBarShadow" }) {
-      shadowView.frame = tabBar.frame
-    } else {
-      view.bringSubviewToFront(tabBar)
-    }
+    tabBar.isHidden = true
   }
 }


### PR DESCRIPTION
이슈 #148 

## 완료된 기능
- UITabBarController TabBar hidden 처리

## 전달사항
- UITabBarController의 TabBar를 hidden처리해서 우선적으로 탭 이동시 보이던 UITabBar는 안보이게 설정했음 (도대체 왜 보이는 건지 모르겠다..)
- 안보이고 동작을 안해도 탭바가 차지하고 있는 영역은 그대로 이기 때문에 bottom ignoreSafeArea처리해서 사용해야하는 번거로움이 있음
- 추후에 View를 감싸는 BaseView를 통해 기본 Modifier들을 처리하면 될 것 같음!
