### PR TITLE
[Feature/#153] 프로필 설정 중 앱 종료 시 대응

### DIFF
--- a/Projects/Domain/Profile/Interface/Sources/API/ProfileAPI.swift
+++ b/Projects/Domain/Profile/Interface/Sources/API/ProfileAPI.swift
@@ -16,6 +16,7 @@ public enum ProfileAPI {
   case registerIntroduction(requestData: RegisterIntroductionRequestDTO)
   case checkIntroduction
   case uploadProfileImage(data: Data)
+  case fetchUserProfileStatus
 }
 
 extension ProfileAPI: BaseTargetType {
@@ -29,6 +30,8 @@ extension ProfileAPI: BaseTargetType {
       return "api/v1/profile/introduction/exist"
     case .uploadProfileImage:
       return "api/v1/profile/images"
+    case .fetchUserProfileStatus:
+      return "api/v1/profile/status"
     }
   }
   
@@ -42,6 +45,8 @@ extension ProfileAPI: BaseTargetType {
       return .get
     case .uploadProfileImage:
       return .post
+    case .fetchUserProfileStatus:
+      return .get
     }
   }
   
@@ -62,6 +67,8 @@ extension ProfileAPI: BaseTargetType {
       )
       
       return .uploadMultipart([imageData])
+    case .fetchUserProfileStatus:
+      return .requestPlain
     }
   }
 }

--- a/Projects/Domain/Profile/Interface/Sources/DTO/Response/ProfileStatusResponseDTO.swift
+++ b/Projects/Domain/Profile/Interface/Sources/DTO/Response/ProfileStatusResponseDTO.swift
@@ -1,0 +1,27 @@
+//
+//  ProfileStatusResponseDTO.swift
+//  DomainProfileInterface
+//
+//  Created by 임현규 on 8/18/24.
+//
+
+import Foundation
+
+public struct ProfileStatusResponseDTO: Decodable {
+  let userProfileStatus: String?
+  
+  public func toDomain() -> UserProfileStatus {
+    switch userProfileStatus {
+    case "EMPTY":
+      return .empty
+    case "ONLY_PROFILE_CREATED":
+      return .doneProfileSelect
+    case "INTRODUCE_DONE":
+      return .doneIntroduction
+    case "PHOTO_DONE":
+      return .doneProfileImage
+    default:
+      return .empty
+    }
+  }
+}

--- a/Projects/Domain/Profile/Interface/Sources/Entity/UserProfileStatus.swift
+++ b/Projects/Domain/Profile/Interface/Sources/Entity/UserProfileStatus.swift
@@ -1,0 +1,19 @@
+//
+//  UserProfileStatus.swift
+//  DomainProfileInterface
+//
+//  Created by 임현규 on 8/18/24.
+//
+
+import Foundation
+
+public enum UserProfileStatus {
+  /// 프로필이 아무것도 작성되지 않음
+  case empty
+  /// 온보딩 프로필 키워드 선택까지 완료된 상태
+  case doneProfileSelect
+  /// 자기소개까지 작성 완료된 상태
+  case doneIntroduction
+  /// 프로필 이미지까지 완료된 상태
+  case doneProfileImage
+}

--- a/Projects/Domain/Profile/Interface/Sources/ProfileClient.swift
+++ b/Projects/Domain/Profile/Interface/Sources/ProfileClient.swift
@@ -9,29 +9,31 @@ import Foundation
 import ComposableArchitecture
 
 public struct ProfileClient {
-  private var checkExistIntroduction: () async throws -> Bool
+  private var checkIsExistIntroduction: () async throws -> Bool
   private var registerIntroduction: (String) async throws -> Void
   private var fetchProfileSelect: () async throws -> ProfileSelect
   private var uploadProfileImage: (Data) async throws -> Void
   private var fetchUserProfile: () async throws -> UserProfile
-
+  private var checkIsExistProfileSelect: () async throws -> Bool
   
   public init(
-    checkExistIntroduction: @escaping () async throws -> Bool,
+    checkIsExistIntroduction: @escaping () async throws -> Bool,
     registerIntroduction: @escaping (String) async throws -> Void,
     fetchProfileSelect: @escaping () async throws -> ProfileSelect,
     uploadProfileImage: @escaping (Data) async throws -> Void,
-    fetchUserProfile: @escaping () async throws -> UserProfile
+    fetchUserProfile: @escaping () async throws -> UserProfile,
+    checkIsExistProfileSelect: @escaping () async throws -> Bool
   ) {
-    self.checkExistIntroduction = checkExistIntroduction
+    self.checkIsExistIntroduction = checkIsExistIntroduction
     self.registerIntroduction = registerIntroduction
     self.fetchProfileSelect = fetchProfileSelect
     self.uploadProfileImage = uploadProfileImage
     self.fetchUserProfile = fetchUserProfile
+    self.checkIsExistProfileSelect = checkIsExistProfileSelect
   }
   
-  public func checkExistIntroduction() async throws -> Bool {
-    try await checkExistIntroduction()
+  public func checkIsExistIntroduction() async throws -> Bool {
+    try await checkIsExistIntroduction()
   }
   
   public func registerIntroduction(answer: String) async throws -> Void {
@@ -48,6 +50,10 @@ public struct ProfileClient {
   
   public func fetchUserProfile() async throws -> UserProfile {
     try await fetchUserProfile()
+  }
+  
+  public func checkIsExistProfileSelect() async throws -> Bool {
+    try await checkIsExistProfileSelect()
   }
 }
  

--- a/Projects/Domain/Profile/Interface/Sources/ProfileClient.swift
+++ b/Projects/Domain/Profile/Interface/Sources/ProfileClient.swift
@@ -9,31 +9,31 @@ import Foundation
 import ComposableArchitecture
 
 public struct ProfileClient {
-  private var checkIsExistIntroduction: () async throws -> Bool
+  private var checkExistIntroduction: () async throws -> Bool
   private var registerIntroduction: (String) async throws -> Void
   private var fetchProfileSelect: () async throws -> ProfileSelect
   private var uploadProfileImage: (Data) async throws -> Void
   private var fetchUserProfile: () async throws -> UserProfile
-  private var checkIsExistProfileSelect: () async throws -> Bool
+  private var fetchUserProfileSelect: () async throws -> UserProfileStatus
   
   public init(
-    checkIsExistIntroduction: @escaping () async throws -> Bool,
+    checkExistIntroduction: @escaping () async throws -> Bool,
     registerIntroduction: @escaping (String) async throws -> Void,
     fetchProfileSelect: @escaping () async throws -> ProfileSelect,
     uploadProfileImage: @escaping (Data) async throws -> Void,
     fetchUserProfile: @escaping () async throws -> UserProfile,
-    checkIsExistProfileSelect: @escaping () async throws -> Bool
+    fetchUserProfileSelect: @escaping () async throws -> UserProfileStatus
   ) {
-    self.checkIsExistIntroduction = checkIsExistIntroduction
+    self.checkExistIntroduction = checkExistIntroduction
     self.registerIntroduction = registerIntroduction
     self.fetchProfileSelect = fetchProfileSelect
     self.uploadProfileImage = uploadProfileImage
     self.fetchUserProfile = fetchUserProfile
-    self.checkIsExistProfileSelect = checkIsExistProfileSelect
+    self.fetchUserProfileSelect = fetchUserProfileSelect
   }
   
-  public func checkIsExistIntroduction() async throws -> Bool {
-    try await checkIsExistIntroduction()
+  public func checkExistIntroduction() async throws -> Bool {
+    try await checkExistIntroduction()
   }
   
   public func registerIntroduction(answer: String) async throws -> Void {
@@ -52,8 +52,8 @@ public struct ProfileClient {
     try await fetchUserProfile()
   }
   
-  public func checkIsExistProfileSelect() async throws -> Bool {
-    try await checkIsExistProfileSelect()
+  public func fetchUserProfileSelect() async throws -> UserProfileStatus {
+    try await fetchUserProfileSelect()
   }
 }
  

--- a/Projects/Domain/Profile/Sources/ProfileClient.swift
+++ b/Projects/Domain/Profile/Sources/ProfileClient.swift
@@ -42,10 +42,10 @@ extension ProfileClient: DependencyKey {
         let userProfile = responseData.toProfileDomain()
         return userProfile
       },
-      checkIsExistProfileSelect: {
+      fetchUserProfileSelect: {
         let responseData = try await networkManager.reqeust(api: .apiType(ProfileAPI.fetchUserProfileStatus), dto: ProfileStatusResponseDTO.self)
         let userStatus = responseData.toDomain()
-        return userStatus == .empty ? false : true
+        return userStatus
       }
     )
   }

--- a/Projects/Domain/Profile/Sources/ProfileClient.swift
+++ b/Projects/Domain/Profile/Sources/ProfileClient.swift
@@ -40,8 +40,12 @@ extension ProfileClient: DependencyKey {
       fetchUserProfile: {
         let responseData = try await networkManager.reqeust(api: .apiType(ProfileAPI.fetchProfile), dto: ProfileResponseDTO.self)
         let userProfile = responseData.toProfileDomain()
-        print(userProfile)
         return userProfile
+      },
+      checkIsExistProfileSelect: {
+        let responseData = try await networkManager.reqeust(api: .apiType(ProfileAPI.fetchUserProfileStatus), dto: ProfileStatusResponseDTO.self)
+        let userStatus = responseData.toDomain()
+        return userStatus == .empty ? false : true
       }
     )
   }

--- a/Projects/Feature/Sources/App/AppView.swift
+++ b/Projects/Feature/Sources/App/AppView.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-import FeatureLogin
 import FeatureLoginInterface
+import FeatureOnboardingInterface
 
 import ComposableArchitecture
 
@@ -26,6 +26,8 @@ public struct AppView: View {
           MainTabView(store: tabViewStore)
         } else if let loginStore = store.scope(state: \.login, action: \.login) {
           LoginView(store: loginStore)
+        } else if let onboardingStore = store.scope(state: \.onboarding, action: \.onboarding) {
+          OnboardingView(store: onboardingStore)
         } else {
           SplashView()
         }


### PR DESCRIPTION
이슈 #153 

https://github.com/user-attachments/assets/864bb038-45d3-4a1a-9aaf-d4a545c56650




## 완료된 기능
- UserStatus fetch API 추가
- 프로필 작성 여부 확인 후 상황에 맞는 View 처리

## 전달사항
### Client의 역할
현재 Client의 역할이 다분화되어있음
1. entity를 그대로 feature 레이어에 전달
2. entity를 통해 비즈니스 로직을 수행 한뒤 결과값을 전달.

1의 경우에는 feature에서 비즈니스 로직을 수행하기 때문에 client 내부 메소드가 여러 feature에서 재사용이 가능하다는 장점이 있지만
2의 경우에는 같은 API라도 내부에서 처리하는 로직이 다른 경우 client 내부에서 여러 메소드를 둬서 동일한 API를 호출하고 있음.

통일되지 않은 client의 역할을 확실하게 잡고가야 추후에 유지보수 시 좀 더 명확하게 작업을 할 수 있을 거 같음

1. data layer를 새로 만들어서 현재 domain 레이어에 있는 client에서 비즈니스 로직 처리
2. client는 entity를 feature 레이어에 전달하는 역할만 가지고 비즈니스 로직은 feature에서 처리.