### PR TITLE
[Feature/#195] 매칭 화면 카카오톡 바로가기 버튼 구현

### DIFF
--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
@@ -175,7 +175,13 @@ private extension MatchingView {
     case .waiting:
       EmptyView()
     case .success:
-      EmptyView()
+      SolidButton(
+        title: "카카오톡 바로가기",
+        sizeType: .large,
+        buttonType: .throttle,
+        action: { openKakaoTalk() }
+      )
+    
     case .failure:
       SolidButton(
         title: "다른 보틀 열어보기",
@@ -240,5 +246,14 @@ private extension MatchingView {
         )
     )
     .padding(.bottom, 32.0)
+  }
+}
+
+private extension MatchingView {
+  // TODO: 추후 구조 변경 필요
+  func openKakaoTalk() {
+    let kakaoTalk = "kakaotalk://"
+    guard let kakaoTalkURL = NSURL(string: kakaoTalk) as? URL, UIApplication.shared.canOpenURL(kakaoTalkURL) else { return }
+    UIApplication.shared.open(kakaoTalkURL)
   }
 }

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Matching/MatchingView.swift
@@ -13,6 +13,7 @@ import ComposableArchitecture
 
 public struct MatchingView: View {
   @Perception.Bindable private var store: StoreOf<MatchingFeature>
+  @Environment(\.openURL) var openURL
   
   public init(store: StoreOf<MatchingFeature>) {
     self.store = store
@@ -253,7 +254,7 @@ private extension MatchingView {
   // TODO: 추후 구조 변경 필요
   func openKakaoTalk() {
     let kakaoTalk = "kakaotalk://"
-    guard let kakaoTalkURL = NSURL(string: kakaoTalk) as? URL, UIApplication.shared.canOpenURL(kakaoTalkURL) else { return }
-    UIApplication.shared.open(kakaoTalkURL)
+    guard let kakaoTalkURL = NSURL(string: kakaoTalk) as? URL else { return }
+    openURL(kakaoTalkURL)
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -25,7 +25,7 @@ public extension InfoPlist {
             "BASE_URL": "$(BASE_URL)",
             "WEB_VIEW_BASE_URL": "$(WEB_VIEW_BASE_URL)",
             "WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME": "$(WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME)",
-            "LSApplicationQueriesSchemes": ["kakaokompassauth"],
+            "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaotalk"],
             "CFBundleURLTypes": [
                 [
                     "CFBundleTypeRole": "Editor",
@@ -49,7 +49,7 @@ public extension InfoPlist {
             "BASE_URL": "$(BASE_URL)",
             "WEB_VIEW_BASE_URL": "$(WEB_VIEW_BASE_URL)",
             "WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME": "$(WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME)",
-            "LSApplicationQueriesSchemes": ["kakaokompassauth"],
+            "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaotalk"],
             "CFBundleURLTypes": [
                 [
                     "CFBundleTypeRole": "Editor",


### PR DESCRIPTION
이슈 #195 

## 완료된 기능
- InfoPlist 카카오톡 Scheme 추가
- 카카오톡 바로가기 버튼 구현

## 고민 사항
- SwiftUI로 URL Scheme으로 외부 앱을 실행하려면 `@Environment(\.openURL)`을 사용해야함
- 카카오톡 버튼 클릭 action을 feature 내부에서 처리하려면 feature가 SwiftUI에 대한 의존성이 추가되어야 함
- 일단 위 방식은 제외하고 View 내부에서 들어온 action을 처리해서 openURL을 통해 카카오톡 앱을 열도록 구현함.
- 찾아보니 TCA의 Environment을 사용하는 방식이 있던데 추후에 고도화하겠음!

## 관련 자료
https://github.com/Shimmur/composable-open-url/blob/main/Demo%20Project/ComposableOpenURLDemo/OpeningURLView.swift

https://github.com/Shimmur/composable-open-url