### PR TITLE
[Feature#220] 이미지 다운 샘플링 reszieScale 수정

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Extension/UIImage+Extensions.swift
+++ b/Projects/Shared/DesignSystem/Sources/Extension/UIImage+Extensions.swift
@@ -16,7 +16,7 @@ public extension UIImage {
     while Double(imageSize) > targetMB * pow(2, 20) {
       compressedImage = self.resized(toLength: Double(resizeLength) * resizeScale)
       imageSize = compressedImage?.jpegData(compressionQuality: 0.8)?.count ?? 0
-      resizeScale = 0.75
+      resizeScale *= 0.75
     }
     
     return compressedImage?.jpegData(compressionQuality: 0.8)


### PR DESCRIPTION
이슈 #220 

## 완료된 기능
- 이미지 다운 샘플링 resizeScale 수정

## 전달 사항
시뮬레이터 내장 이미지 중 가장 큰 데이터로 테스트했었을 때는 문제가 없었지만 해당 이미지들보다 더 큰 이미지를 사용자가 선택했을 때
resizeScale이 0.75로 고정되어있다보니 targetSize로 압축하지 못해 무한 루프를 도는 현상이 발생했음

반복문을 돌때마다 0.75배씩 줄어들게 해서 이미지가 반복적으로 작아지게 해 targetSize보다 작아지도록 수정함.

테스트코드 빨리 작성해야될 듯!!



