### PR TITLE
[fix#223] 이미지 선택 시 버튼 활성화되지 않는 버그

### DIFF
--- a/Projects/Feature/ProfileSetup/Interface/Sources/ProfileImageUpload/ProfileImageUploadView.swift
+++ b/Projects/Feature/ProfileSetup/Interface/Sources/ProfileImageUpload/ProfileImageUploadView.swift
@@ -23,35 +23,37 @@ public struct ProfileImageUploadView: View {
   }
   
   public var body: some View {
-    ScrollView {
-      VStack(spacing: 0.0) {
-        titleView
-        
-        PhotosPicker(
-          selection: $selectedItems,
-          maxSelectionCount: 1,
-          matching: .images
-        ) {
-          imagePickerButton
-            .frame(height: UIScreen.main.bounds.width - 16.0 * 2)
-            .padding(.bottom, .md)
+    WithPerceptionTracking {
+      ScrollView {
+        VStack(spacing: 0.0) {
+          titleView
+          
+          PhotosPicker(
+            selection: $selectedItems,
+            maxSelectionCount: 1,
+            matching: .images
+          ) {
+            imagePickerButton
+              .frame(height: UIScreen.main.bounds.width - 16.0 * 2)
+              .padding(.bottom, .md)
+          }
+          .onChange(of: selectedItems) { item in
+            handleSelectedPhotos(item)
+          }
+          
+          doneButton
         }
-        .onChange(of: selectedItems) { item in
-          handleSelectedPhotos(item)
+        .padding(.bottom, .xl)
+      }
+      .padding(.horizontal, .md)
+      .setNavigationBar {
+        makeNaivgationleftButton {
+          store.send(.backButtonDidTapped)
         }
-        
-        doneButton
       }
-      .padding(.bottom, .xl)
+      .scrollIndicators(.hidden)
+      .toolbar(.hidden, for: .bottomBar)
     }
-    .padding(.horizontal, .md)
-    .setNavigationBar {
-      makeNaivgationleftButton {
-        store.send(.backButtonDidTapped)
-      }
-    }
-    .scrollIndicators(.hidden)
-    .toolbar(.hidden, for: .bottomBar)
   }
 }
 


### PR DESCRIPTION
이슈 #223 

## 완료된 기능
- ProfileImageUploadView WithPerceptionTracking 추가

## 전달사항
- 전달받은 캐릭터 이미지를 통해서 1.0.5 release버전으로 테스트를 해본 결과 문제 없이 작동함.
- 제보받은 디바이스의 화면을 확인해봤을 때 이미지 선택 후 imagePickerButton에 선택된 이미지가 보여지는 것을 봐서는 이미지 선택하는 로직쪽에는 문제가 없는 것 같음

``` swift

private extension ProfileImageUploadView {
  func handleSelectedPhotos(_ newPhotos: [PhotosPickerItem]) {
    for newPhoto in newPhotos {
      newPhoto.loadTransferable(type: Data.self) { result in
        switch result {
        case .success(let data):
          if let data = data, let newImage = UIImage(data: data) {
            DispatchQueue.main.async {
              selectedImage = [newImage] // 빈 값
              let compressData = newImage.compressImageData() // nil로 처리
              store.send(.imageDidSelected(selectedImageData: compressData ?? .init()))
            }
          }
          
          // TODO: 이미지 로드 실패 처리
        case .failure(_):
          return
        }
      }
    }
    
    selectedItems.removeAll()
  }
}

```

버튼을 활성화시키는 부분은 Action의 `imageDidSelected` 을 통해 State의 `isDisableDoneButton` 의 값을 변경시켜 doneButton의 활성화여부를 바인딩해주고 있음.

각각 selectedImage에 빈 배열과 nil을 넣어도 문제없이 버튼이 활성화됨. 
따라서, store 쪽에서 문제가 발생하는 것으로 판단했고 확인해보니깐 WithPerceptionTracking 관련해서 경고를 내뿜고 있었음

일단 ProfileImageUploadView body를 WithPerceptionTracking로 감싸서 view에서 store의 상태변경을 잘 추적하도록 함.

버그가 재연이 안되다보니 완벽하게 해결된지는 모르겠음...

