### PR TITLE
[Feature/#239] 강제 업데이트 구현

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Modules.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Modules.swift
@@ -48,6 +48,7 @@ public extension ModulePath {
 
 public extension ModulePath {
     enum Domain: String, CaseIterable {
+        case Error
         case User
         case Report
         case WebView

--- a/Projects/Domain/Auth/Interface/Sources/API/AuthAPI.swift
+++ b/Projects/Domain/Auth/Interface/Sources/API/AuthAPI.swift
@@ -18,6 +18,7 @@ public enum AuthAPI {
   case logout(_ logOutRequestDTO: LogOutRequestDTO)
   case revoke
   case profile(_ requestDTO: ProfileRequestDTO)
+  case updateVersion
 }
 
 extension AuthAPI: BaseTargetType {
@@ -35,6 +36,8 @@ extension AuthAPI: BaseTargetType {
       return "api/v1/auth/apple/revoke"
     case .profile:
       return "api/v2/auth/profile"
+    case .updateVersion:
+      return "api/v1/auth/app-version"
     }
   }
   
@@ -51,6 +54,8 @@ extension AuthAPI: BaseTargetType {
     case .revoke:
       return .get
     case .profile:
+      return .post
+    case .updateVersion:
       return .post
     }
   }
@@ -69,6 +74,8 @@ extension AuthAPI: BaseTargetType {
       return .requestPlain
     case .profile(let requestDTO):
       return .requestJSONEncodable(requestDTO)
+    case .updateVersion:
+      return .requestPlain
     }
   }
 }

--- a/Projects/Domain/Auth/Interface/Sources/API/AuthAPI.swift
+++ b/Projects/Domain/Auth/Interface/Sources/API/AuthAPI.swift
@@ -56,7 +56,7 @@ extension AuthAPI: BaseTargetType {
     case .profile:
       return .post
     case .updateVersion:
-      return .post
+      return .get
     }
   }
   

--- a/Projects/Domain/Auth/Interface/Sources/AuthClient.swift
+++ b/Projects/Domain/Auth/Interface/Sources/AuthClient.swift
@@ -33,7 +33,7 @@ public struct AuthClient {
     fetchAppleClientSecret: @escaping () async throws -> String,
     registerUserProfile: @escaping (String) async throws -> Void,
     removeAllToken: @escaping () -> Void,
-    fetchUpdateVersion: @escaping () async throws -> Void
+    checkUpdateVersion: @escaping () async throws -> Void
   ) {
     self.signInWithKakao = signInWithKakao
     self.signInWithApple = signInWithApple
@@ -46,7 +46,7 @@ public struct AuthClient {
     self.fetchAppleClientSecret = fetchAppleClientSecret
     self.registerUserProfile = registerUserProfile
     self._removeAllToken = removeAllToken
-    self.checkUpdateVersion = fetchUpdateVersion
+    self.checkUpdateVersion = checkUpdateVersion
   }
   
   public func signInWithKakao() async throws -> UserInfo {
@@ -92,7 +92,7 @@ public struct AuthClient {
     _removeAllToken()
   }
   
-  public func fetchUpdateVersion() async throws {
+  public func checkUpdateVersion() async throws {
     return try await checkUpdateVersion()
   }
 }

--- a/Projects/Domain/Auth/Interface/Sources/AuthClient.swift
+++ b/Projects/Domain/Auth/Interface/Sources/AuthClient.swift
@@ -19,6 +19,7 @@ public struct AuthClient {
   private let fetchAppleClientSecret: () async throws -> String
   private let registerUserProfile: (String) async throws -> Void
   private let _removeAllToken: () -> Void
+  private let checkUpdateVersion: () async throws -> Void
   
   public init(
     signInWithKakao: @escaping () async throws -> UserInfo,
@@ -31,7 +32,8 @@ public struct AuthClient {
     revokeAppleLogin: @escaping () async throws -> Void,
     fetchAppleClientSecret: @escaping () async throws -> String,
     registerUserProfile: @escaping (String) async throws -> Void,
-    removeAllToken: @escaping () -> Void
+    removeAllToken: @escaping () -> Void,
+    fetchUpdateVersion: @escaping () async throws -> Void
   ) {
     self.signInWithKakao = signInWithKakao
     self.signInWithApple = signInWithApple
@@ -44,6 +46,7 @@ public struct AuthClient {
     self.fetchAppleClientSecret = fetchAppleClientSecret
     self.registerUserProfile = registerUserProfile
     self._removeAllToken = removeAllToken
+    self.checkUpdateVersion = fetchUpdateVersion
   }
   
   public func signInWithKakao() async throws -> UserInfo {
@@ -87,6 +90,10 @@ public struct AuthClient {
   
   public func removeAllToken() {
     _removeAllToken()
+  }
+  
+  public func fetchUpdateVersion() async throws {
+    return try await checkUpdateVersion()
   }
 }
 

--- a/Projects/Domain/Auth/Interface/Sources/DTO/Response/UpdateVersionResponseDTO.swift
+++ b/Projects/Domain/Auth/Interface/Sources/DTO/Response/UpdateVersionResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  UpdateVersionResponseDTO.swift
+//  DomainAuthInterface
+//
+//  Created by JongHoon on 9/10/24.
+//
+
+import Foundation
+
+public struct UpdateVersionResponseDTO: Decodable {
+  public let minimumIosVersion: Int?
+}

--- a/Projects/Domain/Auth/Project.swift
+++ b/Projects/Domain/Auth/Project.swift
@@ -17,7 +17,8 @@ let project = Project.makeModule(
             implements: .Auth,
             factory: .init(
                 dependencies: [
-                    .domain(interface: .Auth)
+                    .domain(interface: .Auth),
+                    .domain(interface: .Error)
                 ]
             )
         ),

--- a/Projects/Domain/Auth/Sources/AuthClient.swift
+++ b/Projects/Domain/Auth/Sources/AuthClient.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import DomainAuthInterface
+import DomainErrorInterface
 import DomainUser
 
 import CoreNetwork
@@ -91,6 +92,22 @@ extension AuthClient: DependencyKey {
       },
       removeAllToken: {
         LocalAuthDataSourceImpl.removeAllToken()
+      },
+      fetchUpdateVersion: {
+//        let minimumIosBuildNumber = try await networkManager.reqeust(api: .apiType(AuthAPI.updateVersion), dto: UpdateVersionResponseDTO.self).minimumIosVersion
+        let minimumIosBuildNumber: Int? = 33
+        guard let minimumIosBuildNumber,
+              let buildNumberString = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
+              let buildNumber = Int(buildNumberString)
+        else {
+          Log.assertion(message: "no minimum ios version or build number")
+          throw DomainError.unknown("no minimum ios version info or build number")
+        }
+        
+        guard minimumIosBuildNumber <= buildNumber
+        else {
+          throw DomainError.AuthError.needUpdateAppVersion
+        }
       }
     )
   }

--- a/Projects/Domain/Auth/Sources/AuthClient.swift
+++ b/Projects/Domain/Auth/Sources/AuthClient.swift
@@ -93,18 +93,18 @@ extension AuthClient: DependencyKey {
       removeAllToken: {
         LocalAuthDataSourceImpl.removeAllToken()
       },
-      fetchUpdateVersion: {
-//        let minimumIosBuildNumber = try await networkManager.reqeust(api: .apiType(AuthAPI.updateVersion), dto: UpdateVersionResponseDTO.self).minimumIosVersion
-        let minimumIosBuildNumber: Int? = 33
-        guard let minimumIosBuildNumber,
-              let buildNumberString = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
+      checkUpdateVersion: {
+        let minimumIosBuildNumber = try await networkManager.reqeust(api: .apiType(AuthAPI.updateVersion), dto: UpdateVersionResponseDTO.self).minimumIosVersion
+        
+        guard let buildNumberString = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
               let buildNumber = Int(buildNumberString)
         else {
-          Log.assertion(message: "no minimum ios version or build number")
-          throw DomainError.unknown("no minimum ios version info or build number")
+          Log.assertion(message: "no build number")
+          throw DomainError.unknown("no build number")
         }
+        let minimumBuildNumber = minimumIosBuildNumber ?? buildNumber
         
-        guard minimumIosBuildNumber <= buildNumber
+        guard minimumBuildNumber <= buildNumber
         else {
           throw DomainError.AuthError.needUpdateAppVersion
         }

--- a/Projects/Domain/Error/Interface/Sources/DomainError.swift
+++ b/Projects/Domain/Error/Interface/Sources/DomainError.swift
@@ -1,0 +1,16 @@
+//
+//  DomainError.swift
+//  DomainError
+//
+//  Created by JongHoon on 9/11/24.
+//
+
+import Foundation
+
+public enum DomainError: Error {
+  public enum AuthError: Error {
+    case needUpdateAppVersion
+  }
+  
+  case unknown(_ message: String? = nil)
+}

--- a/Projects/Domain/Error/Project.swift
+++ b/Projects/Domain/Error/Project.swift
@@ -1,0 +1,22 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePath.Domain.name+ModulePath.Domain.Error.rawValue,
+    targets: [    
+        .domain(
+            interface: .Error,
+            factory: .init()
+        ),
+        .domain(
+            implements: .Error,
+            factory: .init(
+                dependencies: [
+                    .domain(interface: .Error)
+                ]
+            )
+        ),
+
+    ]
+)

--- a/Projects/Domain/Error/Sources/Source.swift
+++ b/Projects/Domain/Error/Sources/Source.swift
@@ -1,0 +1,1 @@
+// This is for Tuist

--- a/Projects/Feature/SandBeach/Interface/Sources/SandBeach/SandBeachFeatureInterface.swift
+++ b/Projects/Feature/SandBeach/Interface/Sources/SandBeach/SandBeachFeatureInterface.swift
@@ -7,10 +7,13 @@
 
 import Foundation
 
-import SharedDesignSystem
-import CoreLoggerInterface
 import DomainProfile
 import DomainBottle
+import DomainAuth
+
+import CoreLoggerInterface
+
+import SharedDesignSystem
 import SharedUtilInterface
 
 import ComposableArchitecture
@@ -57,6 +60,7 @@ public struct SandBeachFeature {
 // MARK: - init {
 extension SandBeachFeature {
   public init() {
+    @Dependency(\.authClient) var authClient
     @Dependency(\.profileClient) var profileClient
     @Dependency(\.bottleClient) var bottleClient
     
@@ -78,6 +82,9 @@ extension SandBeachFeature {
         })
 
         return .run { send in
+//          let test = try await authClient.fetchUpdateVersion()
+//          Log.debug(test)
+          
           let isExsit = try await profileClient.checkExistIntroduction()
           // 자기소개 없는 상태
           if !isExsit {

--- a/Projects/Feature/SandBeach/Interface/Sources/SandBeach/SandBeachView.swift
+++ b/Projects/Feature/SandBeach/Interface/Sources/SandBeach/SandBeachView.swift
@@ -12,7 +12,7 @@ import SharedDesignSystem
 import ComposableArchitecture
 
 public struct SandBeachView: View {
-  private let store: StoreOf<SandBeachFeature>
+  @Perception.Bindable private var store: StoreOf<SandBeachFeature>
   
   public init(store: StoreOf<SandBeachFeature>) {
     self.store = store
@@ -64,6 +64,7 @@ public struct SandBeachView: View {
           }
         }
       }
+      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .onAppear {
         store.send(.onAppear)
       }

--- a/Projects/Feature/Sources/App/AppFeature.swift
+++ b/Projects/Feature/Sources/App/AppFeature.swift
@@ -30,6 +30,7 @@ public struct AppFeature {
     case Login
     case MainTab
     case Onboarding
+    case Splash
   }
   
   @ObservableState
@@ -39,6 +40,7 @@ public struct AppFeature {
     var mainTab: MainTabViewFeature.State?
     var login: LoginFeature.State?
     var onboarding: OnboardingFeature.State?
+    var splash: SplashFeature.State?
     
     public init() {
       self.appDelegate = .init()
@@ -51,6 +53,7 @@ public struct AppFeature {
     case mainTab(MainTabViewFeature.Action)
     case login(LoginFeature.Action)
     case onboarding(OnboardingFeature.Action)
+    case splash(SplashFeature.Action)
     
     case checkUserLoginState
     case sceneDidActive
@@ -78,6 +81,9 @@ public struct AppFeature {
       }
       .ifLet(\.onboarding, action: \.onboarding) {
         OnboardingFeature()
+      }
+      .ifLet(\.splash, action: \.splash) {
+        SplashFeature()
       }
   }
   
@@ -126,6 +132,13 @@ public struct AppFeature {
       switch delegate {
       case let .fcmTokenDidRecevied(fcmToken):
         userClient.updateFcmToken(fcmToken: fcmToken)
+        return changeRoot(.Splash, state: &state)
+      }
+      
+    // Splash Delegate
+    case let .splash(.delegate(delegate)):
+      switch delegate {
+      case .initialCheckCompleted:
         return .send(.checkUserLoginState)
       }
       
@@ -190,17 +203,25 @@ public struct AppFeature {
     case .Login:
       state.mainTab = nil
       state.onboarding = nil
+      state.splash = nil
       state.login = LoginFeature.State()
       userClient.updateLoginState(isLoggedIn: false)
       authClient.removeAllToken()
     case .MainTab:
       state.login = nil
       state.onboarding = nil
+      state.splash = nil
       state.mainTab = MainTabViewFeature.State()
     case .Onboarding:
       state.login = nil
       state.mainTab = nil
+      state.splash = nil
       state.onboarding = OnboardingFeature.State()
+    case .Splash:
+      state.login = nil
+      state.mainTab = nil
+      state.onboarding = nil
+      state.splash = SplashFeature.State()
     }
     
     return .none

--- a/Projects/Feature/Sources/App/AppView.swift
+++ b/Projects/Feature/Sources/App/AppView.swift
@@ -30,8 +30,8 @@ public struct AppView: View {
           LoginView(store: loginStore)
         } else if let onboardingStore = store.scope(state: \.onboarding, action: \.onboarding) {
           OnboardingView(store: onboardingStore)
-        } else {
-          SplashView()
+        } else if let splashStore = store.scope(state: \.splash, action: \.splash) {
+          SplashView(store: splashStore)
         }
       }
       .onAppear {

--- a/Projects/Feature/Sources/SplashView/SplashFeature.swift
+++ b/Projects/Feature/Sources/SplashView/SplashFeature.swift
@@ -1,0 +1,112 @@
+//
+//  SplashFeature.swift
+//  Feature
+//
+//  Created by JongHoon on 9/11/24.
+//
+
+import Foundation
+import UIKit
+
+import CoreLoggerInterface
+
+import DomainAuthInterface
+import DomainErrorInterface
+
+import ComposableArchitecture
+
+@Reducer
+public struct SplashFeature {
+  @Dependency(\.authClient) private var authClient
+  
+  @ObservableState
+  public struct State: Equatable {
+    @Presents var destination: Destination.State?
+  }
+  
+  public enum Action: BindableAction {
+    case onAppear
+    case needUpdateAppVersionErrorOccured
+    
+    case updateAppVersion
+    
+    case delegate(Delegate)
+    public enum Delegate {
+      case initialCheckCompleted
+    }
+    
+    case alert(Alert)
+    public enum Alert: Equatable {
+      case needUpdateAppVersion
+    }
+    
+    case destination(PresentationAction<Destination.Action>)
+    case binding(BindingAction<State>)
+  }
+  
+  
+  public init() {}
+  
+  public var body: some ReducerOf<Self> {
+    Reduce(feature)
+      .ifLet(\.$destination, action: \.destination)
+  }
+  
+  private func feature(
+    state: inout State,
+    action: Action
+  ) -> EffectOf<Self> {
+    switch action {
+    case .onAppear:
+      return .run { send in
+        //        try await authClient.checkUpdateVersion()
+        //        await send(.delegate(.initialCheckCompleted))
+        await send(.needUpdateAppVersionErrorOccured)
+      } catch: { error, send in
+        Log.error(error)
+        // TODO: Error handling
+        if let authError = error as? DomainError.AuthError {
+          switch authError {
+          case .needUpdateAppVersion:
+            await send(.needUpdateAppVersionErrorOccured)
+          }
+        }
+      }
+      
+    case .needUpdateAppVersionErrorOccured:
+      state.destination = .alert(.init(
+        title: { TextState("업데이트 안내") },
+        actions: {
+          ButtonState(
+            action: .needUpdateAppVersion,
+            label: { TextState("업데이트 하기") }
+          )
+        },
+        message: { TextState("최적의 사용 환경을 위해\n최신 버전의 앱으로 업데이트 해주세요") }
+      ))
+      return .none
+      
+    case let .destination(.presented(.alert(alert))):
+      switch alert {
+      case .needUpdateAppVersion:
+        return .send(.updateAppVersion)
+      }
+      
+    case .updateAppVersion:
+      let appStoreURL = URL(string: Bundle.main.infoDictionary?["APP_STORE_URL"] as? String ?? "")!
+      UIApplication.shared.open(appStoreURL)
+      return .none
+      
+    case .alert, .delegate, .destination, .binding:
+      return .none
+    }
+  }
+}
+
+extension SplashFeature {
+  @Reducer(state: .equatable)
+  public enum Destination {
+    case alert(AlertState<SplashFeature.Action.Alert>)
+  }
+}
+

--- a/Projects/Feature/Sources/SplashView/SplashFeature.swift
+++ b/Projects/Feature/Sources/SplashView/SplashFeature.swift
@@ -59,9 +59,8 @@ public struct SplashFeature {
     switch action {
     case .onAppear:
       return .run { send in
-        //        try await authClient.checkUpdateVersion()
-        //        await send(.delegate(.initialCheckCompleted))
-        await send(.needUpdateAppVersionErrorOccured)
+        try await authClient.checkUpdateVersion()
+        await send(.delegate(.initialCheckCompleted))
       } catch: { error, send in
         Log.error(error)
         // TODO: Error handling
@@ -95,7 +94,11 @@ public struct SplashFeature {
     case .updateAppVersion:
       let appStoreURL = URL(string: Bundle.main.infoDictionary?["APP_STORE_URL"] as? String ?? "")!
       UIApplication.shared.open(appStoreURL)
-      return .none
+      return .run { _ in
+        // TODO: Custom Alert 만들면 확인 눌러도 dismiss 되지 않도록 수정
+        try await Task.sleep(nanoseconds: 3000_000_000)
+        exit(0)
+      }
       
     case .alert, .delegate, .destination, .binding:
       return .none
@@ -109,4 +112,3 @@ extension SplashFeature {
     case alert(AlertState<SplashFeature.Action.Alert>)
   }
 }
-

--- a/Projects/Feature/Sources/SplashView/SplashView.swift
+++ b/Projects/Feature/Sources/SplashView/SplashView.swift
@@ -6,17 +6,31 @@
 //
 
 import SwiftUI
+
 import SharedDesignSystem
 
+import ComposableArchitecture
+
 public struct SplashView: View {
-  public init() {}
+  @Perception.Bindable private var store: StoreOf<SplashFeature>
+  
+  public init(store: StoreOf<SplashFeature>) {
+    self.store = store
+  }
+  
   public var body: some View {
-    ZStack {
-      ColorToken.container(.pressed).color
-        .ignoresSafeArea()
-      
-      Image.BottleImageSystem.illustraition(.splash).image
+    WithPerceptionTracking {
+      ZStack {
+        ColorToken.container(.pressed).color
+          .ignoresSafeArea()
+        
+        Image.BottleImageSystem.illustraition(.splash).image
+      }
+      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
+      .ignoresSafeArea()
+      .task {
+        store.send(.onAppear)
+      }
     }
-    .ignoresSafeArea()
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -25,6 +25,7 @@ public extension InfoPlist {
             "BASE_URL": "$(BASE_URL)",
             "WEB_VIEW_BASE_URL": "$(WEB_VIEW_BASE_URL)",
             "WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME": "$(WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME)",
+            "APP_STORE_URL": "$(APP_STORE_URL)",
             "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaotalk"],
             "CFBundleURLTypes": [
                 [
@@ -49,6 +50,7 @@ public extension InfoPlist {
             "BASE_URL": "$(BASE_URL)",
             "WEB_VIEW_BASE_URL": "$(WEB_VIEW_BASE_URL)",
             "WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME": "$(WEB_VIEW_MESSAGE_HANDLER_DEFAULT_NAME)",
+            "APP_STORE_URL": "$(APP_STORE_URL)",
             "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaotalk"],
             "CFBundleURLTypes": [
                 [


### PR DESCRIPTION
이슈 #239 

## 완료된 기능
- iOS 최소 업데이트 버전 확인 API 연결
- 강제 업데이트 메소드 구현
- 스플래쉬 화면, 모래 사장 화면 강제업데이트 로직 적용
- Domain Error 구현

## 고민 사항

```swift
let appStoreURL = URL(string: Bundle.main.infoDictionary?["APP_STORE_URL"] as? String ?? "")!
UIApplication.shared.open(appStoreURL)
```
앱스토어로 화면 이동 시키는 로직이 반복돼서  use case로 빼면 좋을거같아서, 혹시 client 로 빼서 반복되는 로직 관리하는 게 좋을거같은데 어떻게 생각해??
