### PR TITLE
[Feature/#232] 커스텀 alert 적용

### DIFF
--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailFeatureInterface.swift
@@ -43,6 +43,8 @@ public struct PingPongDetailFeature {
     var matching: MatchingFeature.State
     var selectedTab: PingPongDetailViewTabType
     
+    @Presents var destination: Destination.State?
+
     public init(
       bottleID: Int,
       isRead: Bool,
@@ -67,7 +69,7 @@ public struct PingPongDetailFeature {
     case pingPongDidFetched(_: BottlePingPong)
     case backButtonDidTapped
     case reportButtonDidTapped
-    
+    case stopTalkAlertDidRequired
     
     // Delegate
     case delegate(Delegate)
@@ -83,6 +85,13 @@ public struct PingPongDetailFeature {
     case questionAndAnswer(QuestionAndAnswerFeature.Action)
     case matching(MatchingFeature.Action)
     case binding(BindingAction<State>)
+    case destination(PresentationAction<Destination.Action>)
+    // Alert
+    case alert(Alert)
+    public enum Alert: Equatable {
+      case confirmStopTalk
+      case dismiss
+    }
   }
   
   public var body: some ReducerOf<Self> {
@@ -97,6 +106,15 @@ public struct PingPongDetailFeature {
       MatchingFeature()
     }
     reducer
+      .ifLet(\.$destination, action: \.destination)
   }
 }
 
+// MARK: - Destination
+
+extension PingPongDetailFeature {
+  @Reducer(state: .equatable)
+  public enum Destination {
+    case alert(AlertState<PingPongDetailFeature.Action.Alert>)
+  }
+}

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/PingPongDetail/PingPongDetailView.swift
@@ -55,6 +55,7 @@ public struct PingPongDetailView: View {
       }
     )
     .ignoresSafeArea(.all, edges: .bottom)
+    .bottleAlert($store.scope(state: \.destination?.alert, action: \.destination.alert))
   }
 }
 

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeature.swift
@@ -33,26 +33,7 @@ extension IntroductionFeature {
         return .none
         
       case .stopTaskButtonTapped:
-        state.destination = .alert(.init(
-          title: { TextState("중단하기") },
-          actions: {
-            ButtonState(
-              role: .destructive,
-              action: .confirmStopTalk,
-              label: { TextState("중단하기") })
-          },
-          message: { TextState("중단 시 모든 핑퐁 내용이 사라져요. 정말 중단하시겠어요?") }
-        ))
-        return .none
-        
-      case let .destination(.presented(.alert(alert))):
-        switch alert {
-        case .confirmStopTalk:
-          return .run { [bottleID = state.bottleID] send in
-            try await bottleClient.stopTalk(bottleID: bottleID)
-            await send(.delegate(.popToRootDidRequired))
-          }
-        }
+        return .send(.delegate(.stopTaskButtonTapped))
         
       case .refreshPingPongDidRequired:
         return .run { [bottleID = state.bottleID] send in
@@ -62,7 +43,7 @@ extension IntroductionFeature {
           await send(.introductionFetched(pingPong.introduction ?? []))
         }
         
-      case .binding, .alert:
+      case .binding:
         return .none
         
       default:

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionFeatureInterface.swift
@@ -68,9 +68,7 @@ public struct IntroductionFeature {
         + (interest?.etc ?? [])
         + (interest?.sports ?? [])
     }
-    
-    @Presents var destination: Destination.State?
-    
+  
     public init (bottleID: Int) { 
       self.bottleID = bottleID
     }
@@ -88,32 +86,14 @@ public struct IntroductionFeature {
     
     // ETC.
     case binding(BindingAction<State>)
-    case destination(PresentationAction<Destination.Action>)
-    
-    case alert(Alert)
-    public enum Alert: Equatable {
-      case confirmStopTalk
-    }
-    
     case delegate(Delegate)
     
     public enum Delegate {
-      case popToRootDidRequired
+      case stopTaskButtonTapped
     }
   }
   
   public var body: some ReducerOf<Self> {
     reducer
-      .ifLet(\.$destination, action: \.destination)
   }
 }
-
-// MARK: - Destination
-
-extension IntroductionFeature {
-  @Reducer(state: .equatable)
-  public enum Destination {
-    case alert(AlertState<IntroductionFeature.Action.Alert>)
-  }
-}
-

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/Introduction/IntroductionView.swift
@@ -81,9 +81,7 @@ public struct IntroductionView: View {
         .padding(.top, 32.0)
       }
       .scrollIndicators(.hidden)
-      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .background(to: ColorToken.background(.primary))
-      
     }
   }
 }

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeature.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeature.swift
@@ -83,30 +83,10 @@ extension QuestionAndAnswerFeature {
         }
         
       case .stopTalkButtonDidTapped:
-        state.destination = .alert(.init(
-          title: { TextState("중단하기") },
-          actions: {
-            ButtonState(
-              role: .destructive,
-              action: .confirmStopTalk,
-              label: { TextState("중단하기") })
-          },
-          message: { TextState("중단 시 모든 핑퐁 내용이 사라져요. 정말 중단하시겠어요?") }
-        ))
-        return .none
+        return .send(.delegate(.stopTaskButtonDidTapped))
         
       case .refreshDidPulled:
         return .send(.delegate(.refreshPingPong))
-
-      case let .destination(.presented(.alert(alert))):
-        switch alert {
-        case .confirmStopTalk:
-          state.isShowLoadingIndicator = true
-          return .run { [bottleID = state.bottleID] send in
-            try await bottleClient.stopTalk(bottleID: bottleID)
-            await send(.delegate(.popToRootDidRequired))
-          }
-        }
         
       case .binding(\.firstLetterTextFieldContent):
         if state.firstLetterTextFieldContent.count >= 50 {
@@ -132,7 +112,7 @@ extension QuestionAndAnswerFeature {
         }
         return .none
         
-      case .binding, .destination, .alert:
+      case .binding:
         return .none
         
       default:

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeatureInterface.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerFeatureInterface.swift
@@ -114,9 +114,7 @@ public struct QuestionAndAnswerFeature {
     }
     var finalSelectIsSelctedYesButton: Bool
     var finalSelectIsSelctedNoButton: Bool
-    
-    @Presents var destination: Destination.State?
-    
+        
     public init(bottleID: Int) {
       self.bottleID = bottleID
       self.isShowLoadingIndicator = false
@@ -181,12 +179,6 @@ public struct QuestionAndAnswerFeature {
     
     // ETC.
     case binding(BindingAction<State>)
-    case destination(PresentationAction<Destination.Action>)
-    
-    case alert(Alert)
-    public enum Alert: Equatable {
-      case confirmStopTalk
-    }
     
     case delegate(Delegate)
     
@@ -194,21 +186,12 @@ public struct QuestionAndAnswerFeature {
       case reloadPingPongRequired
       case popToRootDidRequired
       case refreshPingPong
+      case stopTaskButtonDidTapped
     }
   }
   
   public var body: some ReducerOf<Self> {
     BindingReducer()
     reducer
-      .ifLet(\.$destination, action: \.destination)
-  }
-}
-
-// MARK: - Destination
-
-extension QuestionAndAnswerFeature {
-  @Reducer(state: .equatable)
-  public enum Destination {
-    case alert(AlertState<QuestionAndAnswerFeature.Action.Alert>)
   }
 }

--- a/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/PingPongDetail/View/SubViews/QuestionAndAnswer/QuestionAndAnswerView.swift
@@ -134,7 +134,6 @@ public struct QuestionAndAnswerView: View {
           LoadingIndicator()
         }
       }
-      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .background(to: ColorToken.background(.primary))
       .toolbar(.hidden, for: .bottomBar)
 

--- a/Projects/Feature/Report/Interface/Sources/ReportUserFeatureInterface.swift
+++ b/Projects/Feature/Report/Interface/Sources/ReportUserFeatureInterface.swift
@@ -70,6 +70,7 @@ public struct ReportUserFeature {
     case alert(Alert)
     public enum Alert: Equatable {
       case confirmReport
+      case dismiss
     }
     
     // ETC

--- a/Projects/Feature/Report/Interface/Sources/ReportUserView.swift
+++ b/Projects/Feature/Report/Interface/Sources/ReportUserView.swift
@@ -35,7 +35,7 @@ public struct ReportUserView: View {
         }
       }
       .padding(.horizontal, .md)
-      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
+      .bottleAlert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .toolbar(.hidden, for: .bottomBar)
     }
   }

--- a/Projects/Feature/SandBeach/Interface/Sources/SandBeach/SandBeachView.swift
+++ b/Projects/Feature/SandBeach/Interface/Sources/SandBeach/SandBeachView.swift
@@ -64,7 +64,7 @@ public struct SandBeachView: View {
           }
         }
       }
-      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
+      .bottleAlert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .onAppear {
         store.send(.onAppear)
       }

--- a/Projects/Feature/Sources/SplashView/SplashView.swift
+++ b/Projects/Feature/Sources/SplashView/SplashView.swift
@@ -26,7 +26,7 @@ public struct SplashView: View {
         
         Image.BottleImageSystem.illustraition(.splash).image
       }
-      .alert($store.scope(state: \.destination?.alert, action: \.destination.alert))
+      .bottleAlert($store.scope(state: \.destination?.alert, action: \.destination.alert))
       .ignoresSafeArea()
       .task {
         store.send(.onAppear)


### PR DESCRIPTION
이슈 #232 

## 완료된 기능
- SplashView bottleAlert 적용
- PingPongDetailView bottleAlert 적용
- ReportUserView bottleAlert 적용
- SandBeachView bottleAlert 적용

## 고민한 부분

![screenshot-2024-09-24-145953](https://github.com/user-attachments/assets/e570330b-1ba6-4b24-8b55-9bb7cbf77670)


- 기존에 PingPongDetailView는 tabButtons의 상태에 따라 IntroductionView, QuestionAndAnswerView, MatchingView를 보여주고 있었음
- IntroductionView, QuestionAndAnswerView은 각각 AlertState와 destination을 가지고 Alert를 띄워주고 있음
- 현재 bottleAlert Modifier는 ZStack으로 현재 View에 Custom Alert를 띄우는 방식이다보니 전체 화면에 Alert가 띄워지는게 아니라 IntroductionView, QuestionAndAnswerView에 Alert가 띄워짐 -> 위의 이미지처럼 됨
- 따라서, PingPongDetailView에서 Alert를 띄우는 거로 변경해서 해결