### PR TITLE
[Fix/#314] 보틀 보관함 하단에 탭 높이만큼 패딩값 추가 필요

### DIFF
--- a/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageView.swift
+++ b/Projects/Feature/BottleStorage/Interface/Sources/BottleStorage/BottleStorageView.swift
@@ -29,16 +29,13 @@ public struct BottleStorageView: View {
           bottlsList
             .padding(.horizontal, .md)
             .padding(.top, 32.0)
-            .padding(.bottom, 36.0)
-  
-          Spacer()
         }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(to: ColorToken.background(.primary))
+        .padding(.bottom, BottleConstants.bottomTabBarHeight.value)
         .setTabBar(selectedTab: .bottleStorage) { selectedTab in
           store.send(.selectedTabDidChanged(selectedTab: selectedTab))
         }
-        
-        .frame(maxHeight: .infinity, alignment: .top)
-        .background(to: ColorToken.background(.primary))
       } destination: { store in
         WithPerceptionTracking {
           switch store.state {
@@ -135,6 +132,9 @@ private extension BottleStorageView {
             }
           }
         }
+        
+        Spacer()
+          .frame(height: 36.0)
       }
       .scrollIndicators(.hidden)
     }


### PR DESCRIPTION
> 이슈: #314 

## 작업 사항
- 보틀 보관함 하단에 탭 높이만큼 패딩 값 추가 필요

- 변경 전

https://github.com/user-attachments/assets/b7deea0d-e443-44d3-b073-ec6e988cc89a

- 변경 후

https://github.com/user-attachments/assets/79abb021-9f18-4c49-953d-4055701d915a